### PR TITLE
Bug fix

### DIFF
--- a/pdf_bookmarke.py
+++ b/pdf_bookmarke.py
@@ -97,7 +97,10 @@ def build_bookmark(tocfile, forwardpages, hidelevel=1):
                     cur_depth = str(last_depth)
                     child_num = childrens["l"+cur_depth]
                     childrens["l"+cur_depth] = 0
-                    childrens["l"+str(depth)] += 1
+                    try:
+                        childrens["l"+str(depth)] += 1
+                    except KeyError:
+                        childrens["l"+str(depth)] = 1                    
                 mark = build_mark(title, page, child_num, depth<=hidelevel)
                 marklist.append(mark)
                 child_num = 0


### PR DESCRIPTION
Thank you for the nice repository.
build_bookmark seems to raise KeyError when the last line of source.txt is deeper than depth 1, so let me propose a small change to fix it up 😊

(The corresponding error message below)

Traceback (most recent call last):
  File "pdf_bookmarke.py", line 144, in <module>
    options.hidelevel, options.forwardpages)
  File "pdf_bookmarke.py", line 116, in main
    bookmark = build_bookmark(tocfile, forwardpages, hidelevel)
  File "pdf_bookmarke.py", line 100, in build_bookmark
    childrens["l"+str(depth)] += 1
KeyError: 'l1'